### PR TITLE
Update HelloBar script; remove outdated global var

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,10 @@
+3.0.0 / 2017-06-06
+==================
+
+  * Update to use newest script
+  * Remove _hbq global var
+  * Bump AJS Tester version
+
 2.0.0 / 2016-06-21
 ==================
 

--- a/karma.conf.ci.js
+++ b/karma.conf.ci.js
@@ -33,17 +33,6 @@ var customLaunchers = {
     browserName: 'safari',
     version: '9.0'
   },
-  // FIXME(ndhoule): Bad IE7/8 support in testing packages make these fail
-  // sl_ie_7: {
-  //   base: 'SauceLabs',
-  //   browserName: 'internet explorer',
-  //   version: '7'
-  // },
-  // sl_ie_8: {
-  //   base: 'SauceLabs',
-  //   browserName: 'internet explorer',
-  //   version: '8'
-  // },
   sl_ie_9: {
     base: 'SauceLabs',
     browserName: 'internet explorer',

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,9 +12,8 @@ var integration = require('@segment/analytics.js-integration');
 
 var Hellobar = module.exports = integration('Hello Bar')
   .assumesPageview()
-  .global('_hbq')
   .option('apiKey', '')
-  .tag('<script src="//s3.amazonaws.com/scripts.hellobar.com/{{ apiKey }}.js">');
+  .tag('<script src="//my.hellobar.com/{{ apiKey }}.js">');
 
 /**
  * Initialize.
@@ -25,17 +24,9 @@ var Hellobar = module.exports = integration('Hello Bar')
  */
 
 Hellobar.prototype.initialize = function() {
-  window._hbq = window._hbq || [];
   this.load(this.ready);
 };
 
-/**
- * Loaded?
- *
- * @api private
- * @return {boolean}
- */
-
 Hellobar.prototype.loaded = function() {
-  return !!(window._hbq && window._hbq.push !== Array.prototype.push);
+  return typeof window.hellobar === 'function';
 };

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@segment/analytics.js-core": "^3.0.0",
-    "@segment/analytics.js-integration-tester": "^2.0.0",
+    "@segment/analytics.js-integration-tester": "^3.1.0",
     "@segment/clear-env": "^2.0.0",
     "@segment/eslint-config": "^3.1.1",
     "browserify": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-hellobar",
   "description": "The Hellobar analytics.js integration.",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -10,7 +10,7 @@ describe('Hellobar', function() {
   var analytics;
   var hellobar;
   var options = {
-    apiKey: 'bb900665a3090a79ee1db98c3af21ea174bbc09f'
+    apiKey: 'a18c23dec1b87e9401465165eca61459d405684d'
   };
 
   beforeEach(function() {
@@ -28,14 +28,13 @@ describe('Hellobar', function() {
     sandbox();
   });
 
-  after(function() {
+  afterEach(function() {
     reset();
   });
 
   it('should have the right settings', function() {
     analytics.compare(Hellobar, integration('Hello Bar')
       .assumesPageview()
-      .global('_hbq')
       .option('apiKey', ''));
   });
 
@@ -44,18 +43,7 @@ describe('Hellobar', function() {
       analytics.stub(hellobar, 'load');
     });
 
-    afterEach(function() {
-      reset();
-    });
-
     describe('#initialize', function() {
-      it('should create the window._hbq object', function() {
-        analytics.assert(window._hbq === undefined);
-        analytics.initialize();
-        analytics.page();
-        analytics.assert(window._hbq);
-      });
-
       it('should call #load', function() {
         analytics.initialize();
         analytics.page();


### PR DESCRIPTION
HelloBar has updated their script at some point in the last few months. This updates us to use the newest script. In addition, the _hbq global var is no longer a thing, so this purges that from the integration code. We now check to see if window.hellobar is a function to determine whether or not the script has loaded.

CC @hankim813 